### PR TITLE
Fix Patch feature buggy behaviour

### DIFF
--- a/internal/item/imgur.go
+++ b/internal/item/imgur.go
@@ -193,13 +193,13 @@ func ImgurAddNewImage(base64str string) (string, string) {
 
 func ImgurDeleteImageFromId(mongoId string) {
 	item := MongoGetItem(COLL_FOUND, mongoId, "")
-	// ref := MongoGetImgurRef(mongoId)
 	ref := ImgurRef{}
 	if item.Image_url != "" {
 		ref = MongoGetImgurRefFromLink(item.Image_url)
 		log.Println("ref for", mongoId, "found:", ref)
 	} else {
-		log.Println("No image url found for", mongoId)
+		log.Println("No image url found for", mongoId, ", skipping ImgurDelete")
+		return
 	}
 
 	if ref != (ImgurRef{}) {

--- a/internal/item/modifyItem_test.go
+++ b/internal/item/modifyItem_test.go
@@ -8,6 +8,22 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
+// Checks an `Item` if its expected key-value is met
+func checkUpdateParamsEqual(key string, expected string, object Item) bool {
+	// log.Println("Checking: ")
+	// PrettyPrintStruct(object)
+	tmp, _ := json.Marshal(object)
+	var item map[string]interface{}
+	json.Unmarshal(tmp, &item)
+	if val, ok := item[key]; !ok {
+		log.Println(key, "not found!")
+		return false
+	} else {
+		return (expected == val)
+	}
+
+}
+
 func TestAddUpdateDelete(t *testing.T) {
 	SetupMongo()
 	// Test routine for Lost item (with user id)
@@ -24,17 +40,100 @@ func TestAddUpdateDelete(t *testing.T) {
 	dummyparams["Id"] = []string{id.Hex()}
 	userid, _ := item[0]["User_id"].(string)
 	dummyparams["User_id"] = []string{userid}
-	// Simulate a change in item details
-	item[0]["Id"] = id.Hex()
-	item[0]["Location"] = "New Location"
-	// Patch test
-	bytes, _ = json.Marshal(item[0])
+
+	// Patch Test for Category
+	var verifyItem Item
+
+	// UPDATE 1 UNMAPPABLE PARAM TEST
+	log.Println("Testing PATCH for ONE STRING parameters")
+	updateItem := map[string]string{
+		"Id":       id.Hex(),
+		"User_id":  userid,
+		"Location": "New Location",
+	}
+	bytes, err := json.Marshal(updateItem)
+	if err != nil {
+		log.Println(err.Error())
+	}
 	msg = buildItemMsgJson(dummyparams, bytes)
 	if _, err := DoUpdateItem(msg); err != nil {
 		t.Fatal("Patch item failed:", err.Error())
 	}
+	// Check that item was correctly updated
+	verifyItem = MongoGetItem(COLL_LOST, id.Hex(), userid)
+	if !checkUpdateParamsEqual("Location", updateItem["Location"], verifyItem) {
+		t.Fail()
+		t.Log("Update location only failed!")
+	}
+
+	// UPDATE MAPPABLE ITEMS TEST
+	log.Println("Testing PATCH for MAPPABLE parameters")
+	updateItem = map[string]string{
+		"Id":             id.Hex(),
+		"User_id":        userid,
+		"Contact_method": "Telegram",
+		"Category":       "Notes",
+	}
+	bytes, err = json.Marshal(updateItem)
+	if err != nil {
+		log.Println(err.Error())
+	}
+	msg = buildItemMsgJson(dummyparams, bytes)
+	if _, err := DoUpdateItem(msg); err != nil {
+		t.Fatal("Patch item failed:", err.Error())
+	}
+	// Check that item was correctly updated
+	verifyItem = MongoGetItem(COLL_LOST, id.Hex(), userid)
+	if !checkUpdateParamsEqual("Category", updateItem["Category"], verifyItem) {
+		t.Fail()
+		t.Log("Update Category failed!")
+	}
+	if !checkUpdateParamsEqual("Contact_method", updateItem["Contact_method"], verifyItem) {
+		t.Fail()
+		t.Log("Update Contact_method failed!")
+	}
+
+	// UPDATE MIXABLE ITEMS TEST
+	log.Println("Testing PATCH for MIXED parameters with ADDITION")
+	updateItem = map[string]string{
+		"Id":             id.Hex(),
+		"User_id":        userid,
+		"Contact_method": "Whatsapp",
+		"Category":       "Etc",
+		"Name":           "Debug Add Item Unit Test Final",
+		"Item_details":   "New parameter added",
+	}
+	bytes, err = json.Marshal(updateItem)
+	if err != nil {
+		log.Println(err.Error())
+	}
+	msg = buildItemMsgJson(dummyparams, bytes)
+	if _, err := DoUpdateItem(msg); err != nil {
+		t.Fatal("Patch item failed:", err.Error())
+	}
+	// Check that item was correctly updated
+	verifyItem = MongoGetItem(COLL_LOST, id.Hex(), userid)
+	PrettyPrintStruct(verifyItem)
+	if !checkUpdateParamsEqual("Category", updateItem["Category"], verifyItem) {
+		t.Fail()
+		t.Log("Update Category failed!")
+	}
+	if !checkUpdateParamsEqual("Contact_method", updateItem["Contact_method"], verifyItem) {
+		t.Fail()
+		t.Log("Update Contact_method failed!")
+	}
+	if !checkUpdateParamsEqual("Name", updateItem["Name"], verifyItem) {
+		t.Fail()
+		t.Log("Update Name failed!")
+	}
+	if !checkUpdateParamsEqual("Item_details", updateItem["Item_details"], verifyItem) {
+		t.Fail()
+		t.Log("Update Item_details (new parameter) failed!")
+	}
+
 	// Delete test
 	if _, err := DoDeleteItem(msg); err != nil {
 		log.Fatal("Delete fail for ", id, "; Error:", err.Error())
 	}
+	log.Println("Testing cleanup done!")
 }

--- a/internal/item/mongo.go
+++ b/internal/item/mongo.go
@@ -110,6 +110,7 @@ func MongoGetItem(collname ItemCollections, id string, userid string) Item {
 	myid, err := primitive.ObjectIDFromHex(id)
 	if err != nil {
 		log.Println("Error getting ObjectID from hex")
+		log.Println("Hex:", id)
 	}
 	query := bson.D{{"_id", myid}}
 	if len(userid) > 0 {

--- a/internal/item/test/debug_add_item.json
+++ b/internal/item/test/debug_add_item.json
@@ -1,11 +1,10 @@
 [{
-    "Name": "Debug Add Item",
-    "User_id": "19fa21",
+    "Name": "Debug Add Item Unit Test",
+    "User_id": "debug123",
     "Date": "2022-05-26T08:51:48.782Z",
     "Location": "UTown Bus Stop",
     "Category": "Electronics",
-    "Image_url": "https://upload.wikimedia.org/wikipedia/commons/0/07/Multi-use_water_bottle.JPG",
-    "Item_details": "Blue, Yellow, Red",
     "Contact_details": "@FindNUS",
     "Contact_method": "Line"
-}]
+}
+]

--- a/internal/item/types.go
+++ b/internal/item/types.go
@@ -42,17 +42,17 @@ type NewItem struct {
 }
 
 type PatchItem struct {
-	Id              primitive.ObjectID `bson:"_id"`
-	Name            string             `bson:"Name,omitempty"`
-	Date            time.Time          `bson:"Date,omitempty"`
-	Location        string             `bson:"Location,omitempty"`
-	Category        int                `bson:"Category,omitempty"`
-	Contact_method  int                `bson:"Contact_method,omitempty"`
-	Contact_details string             `bson:"Contact_details,omitempty"`
-	Item_details    string             `bson:"Image_details,omitempty"`
-	Image_url       string             `bson:"Image_url,omitempty"`
-	Image_base64    string             `bson:"Image_base64,omitempty"`
-	User_id         string             `bson:"User_id,omitempty"`
+	Id              primitive.ObjectID `bson:"_id" json:"Id"`
+	Name            string             `bson:"Name,omitempty" json:"Name,omitempty"`
+	Date            time.Time          `bson:"Date,omitempty" json:"Date,omitempty"`
+	Location        string             `bson:"Location,omitempty" json:"Location,omitempty"`
+	Category        int                `bson:"Category,omitempty" json:"Category,omitempty"`
+	Contact_method  int                `bson:"Contact_method,omitempty" json:"Contact_method,omitempty"`
+	Contact_details string             `bson:"Contact_details,omitempty" json:"Contact_details,omitempty"`
+	Item_details    string             `bson:"Item_details,omitempty" json:"Item_details,omitempty"`
+	Image_url       string             `bson:"Image_url,omitempty" json:"Image_url,omitempty"`
+	Image_base64    string             `bson:"-" json:"Image_base64,omitempty"`
+	User_id         string             `bson:"User_id,omitempty" json:"User_id,omitempty"`
 }
 
 type DeletedItem struct {
@@ -107,8 +107,6 @@ func ParseDateString(datestring string) time.Time {
 func GetCategoryType(cat string) int {
 	cat = strings.ToLower(cat)
 	switch cat {
-	case "etc":
-		return 0
 	case "cards":
 		return 1
 	case "notes":
@@ -117,6 +115,8 @@ func GetCategoryType(cat string) int {
 		return 3
 	case "bottles":
 		return 4
+	case "etc":
+		return 5
 	default:
 		return -1
 	}
@@ -127,7 +127,7 @@ func GetCategoryString(cat int32) string {
 	// WARNING: Floating point errors probable
 	switch cat {
 	case 0:
-		return "Etc"
+		return "Etc" //legacy issue
 	case 1:
 		return "Cards"
 	case 2:
@@ -136,6 +136,8 @@ func GetCategoryString(cat int32) string {
 		return "Electronics"
 	case 4:
 		return "Bottles"
+	case 5:
+		return "Etc"
 	default:
 		return "Unknown"
 	}
@@ -145,8 +147,6 @@ func GetCategoryString(cat int32) string {
 func GetContactMethod(method string) int {
 	method = strings.ToLower(method)
 	switch method {
-	case "nus_security":
-		return 0
 	case "telegram":
 		return 1
 	case "whatsapp":
@@ -157,6 +157,8 @@ func GetContactMethod(method string) int {
 		return 4
 	case "phone_number":
 		return 5
+	case "nus_security":
+		return 6
 	default:
 		return -1
 	}
@@ -166,7 +168,7 @@ func GetContactString(cat int32) string {
 	// WARNING: Floating point errors probable
 	switch cat {
 	case 0:
-		return "Nus_security"
+		return "Nus_security" //legacy issue
 	case 1:
 		return "Telegram"
 	case 2:
@@ -177,6 +179,8 @@ func GetContactString(cat int32) string {
 		return "Line"
 	case 5:
 		return "Phone_number"
+	case 6:
+		return "Nus_security"
 	default:
 		return "Unknown"
 	}

--- a/internal/item/utils.go
+++ b/internal/item/utils.go
@@ -29,6 +29,25 @@ func ParseNewItemBody(bytes []byte) []byte {
 	BodyHandleImage_Base64(&generalItem)
 	bytes, err := json.Marshal(generalItem)
 	if err != nil {
+		log.Println("ParseNewItem failed, returning nil due to:", err.Error())
+		return nil
+	}
+	return bytes
+}
+
+// Processes the raw message body, remapping certain fields.
+// Functionally identical to ParseNewItemBody, but does not enforce the existence of certain parameters
+func ParseUpdateItemBody(bytes []byte) []byte {
+	var generalItem map[string]interface{}
+	json.Unmarshal(bytes, &generalItem)
+	// Category Handler
+	BodyHandleCategory(&generalItem)
+	// Other special field handlers
+	BodyHandleContactMethod(&generalItem)
+	BodyHandleImage_Base64(&generalItem)
+	bytes, err := json.Marshal(generalItem)
+	if err != nil {
+		log.Println("ParseUpdateItemBody failed, returning nil due to:", err.Error())
 		return nil
 	}
 	return bytes


### PR DESCRIPTION
## Changelog
General fix #127:
- Removed strict parameter checking by adapting `ParseNewItemBody` to a new `ParseUpdateItemBody`; c7e41059141c1209ae87f9a0da21b0431097e554
- Use PATCH specific handlers (not DRY practice, but the problem bound is small enough for this to not be unscalable); 6eb47e3013c9c0f5c69e5771fda48471b594c915
- Fix obscure PATCH bug caused by default values; 2d230081ce909757aa627d384aad64e7e887703c
- Performance optimisations; 28b21751209a6085879821d8b1f70afc99a58c1a 
- Refactored testing logic to be more robust; 1c1ad29dc18907198db90059c87dfd9c3a212539